### PR TITLE
Add dependency on graphql to gemspec

### DIFF
--- a/souls.gemspec
+++ b/souls.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("activesupport", ">= 6.1.4")
   gem.add_runtime_dependency("foreman", ">= 0.87.2")
   gem.add_runtime_dependency("google-cloud-pubsub", ">= 2.8.0")
+  gem.add_runtime_dependency("graphql", ">= 1.12.19")
   gem.add_runtime_dependency("paint", ">= 2.2.1")
   gem.add_runtime_dependency("tty-prompt", ">= 0.23.1")
   gem.add_runtime_dependency("whirly", ">= 0.3.0")


### PR DESCRIPTION
## Summary

Add dependency on graphql to gemspec

## Other Information

If you run `gem install souls` and then `souls -v`, it will fail.

```
❯ gem install souls
Fetching unicode-display_width-2.1.0.gem
Fetching wisper-2.0.1.gem
Fetching whirly-0.3.0.gem
Fetching tty-screen-0.8.1.gem
Fetching tty-color-0.6.0.gem
Fetching pastel-0.8.0.gem
Fetching tty-cursor-0.7.1.gem
Fetching tty-reader-0.9.0.gem
Fetching thor-1.1.0.gem
Fetching tty-prompt-0.23.1.gem
Fetching paint-2.2.1.gem
Fetching google-protobuf-3.19.1-x86_64-darwin.gem
Fetching googleapis-common-protos-types-1.3.0.gem
Fetching grpc-1.41.1-universal-darwin.gem
Fetching googleapis-common-protos-1.3.12.gem
Fetching grpc-google-iam-v1-1.0.0.gem
Fetching google-cloud-errors-1.2.0.gem
Fetching multi_json-1.15.0.gem
Fetching jwt-2.3.0.gem
Fetching ruby2_keywords-0.0.5.gem
Fetching multipart-post-2.1.1.gem
Fetching faraday-rack-1.0.0.gem
Fetching faraday-patron-1.0.0.gem
Fetching faraday-net_http_persistent-1.2.0.gem
Fetching faraday-net_http-1.0.1.gem
Fetching faraday-httpclient-1.0.1.gem
Fetching faraday-excon-1.1.0.gem
Fetching faraday-em_synchrony-1.0.0.gem
Fetching faraday-em_http-1.0.0.gem
Fetching faraday-1.8.0.gem
Fetching public_suffix-4.0.6.gem
Fetching addressable-2.8.0.gem
Fetching signet-0.16.0.gem
Fetching os-1.1.4.gem
Fetching concurrent-ruby-1.1.9.gem
Fetching memoist-0.16.2.gem
Fetching googleauth-1.1.0.gem
Fetching gapic-common-0.7.0.gem
Fetching google-cloud-pubsub-v1-0.6.1.gem
Fetching google-cloud-env-1.5.0.gem
Fetching google-cloud-core-1.6.0.gem
Fetching zeitwerk-2.5.1.gem
Fetching tzinfo-2.0.4.gem
Fetching activesupport-6.1.4.1.gem
Fetching souls-1.9.15.gem
Fetching google-cloud-pubsub-2.9.0.gem
Fetching foreman-0.87.2.gem
Fetching i18n-1.8.11.gem
Successfully installed unicode-display_width-2.1.0
Successfully installed whirly-0.3.0
Successfully installed wisper-2.0.1
Successfully installed tty-screen-0.8.1
Successfully installed tty-cursor-0.7.1
Successfully installed tty-reader-0.9.0
Successfully installed tty-color-0.6.0
Successfully installed pastel-0.8.0
Successfully installed tty-prompt-0.23.1
Successfully installed thor-1.1.0
Successfully installed paint-2.2.1
Successfully installed google-protobuf-3.19.1-x86_64-darwin
Successfully installed googleapis-common-protos-types-1.3.0
Successfully installed grpc-1.41.1-universal-darwin
Successfully installed googleapis-common-protos-1.3.12
Successfully installed grpc-google-iam-v1-1.0.0
Successfully installed google-cloud-errors-1.2.0
Successfully installed multi_json-1.15.0
Successfully installed jwt-2.3.0
Successfully installed ruby2_keywords-0.0.5
Successfully installed multipart-post-2.1.1
Successfully installed faraday-rack-1.0.0
Successfully installed faraday-patron-1.0.0
Successfully installed faraday-net_http_persistent-1.2.0
Successfully installed faraday-net_http-1.0.1
Successfully installed faraday-httpclient-1.0.1
Successfully installed faraday-excon-1.1.0
Successfully installed faraday-em_synchrony-1.0.0
Successfully installed faraday-em_http-1.0.0
Successfully installed faraday-1.8.0
Successfully installed public_suffix-4.0.6
Successfully installed addressable-2.8.0
Successfully installed signet-0.16.0
Successfully installed os-1.1.4
Successfully installed memoist-0.16.2
Successfully installed googleauth-1.1.0
Successfully installed gapic-common-0.7.0
Successfully installed google-cloud-pubsub-v1-0.6.1
Successfully installed google-cloud-env-1.5.0
Successfully installed google-cloud-core-1.6.0
Successfully installed concurrent-ruby-1.1.9
Successfully installed google-cloud-pubsub-2.9.0
Successfully installed foreman-0.87.2
Successfully installed zeitwerk-2.5.1
Successfully installed tzinfo-2.0.4
Successfully installed i18n-1.8.11
Successfully installed activesupport-6.1.4.1
Successfully installed souls-1.9.15
Parsing documentation for unicode-display_width-2.1.0
Installing ri documentation for unicode-display_width-2.1.0
Parsing documentation for whirly-0.3.0
Installing ri documentation for whirly-0.3.0
Parsing documentation for wisper-2.0.1
Installing ri documentation for wisper-2.0.1
Parsing documentation for tty-screen-0.8.1
Installing ri documentation for tty-screen-0.8.1
Parsing documentation for tty-cursor-0.7.1
Installing ri documentation for tty-cursor-0.7.1
Parsing documentation for tty-reader-0.9.0
Installing ri documentation for tty-reader-0.9.0
Parsing documentation for tty-color-0.6.0
Installing ri documentation for tty-color-0.6.0
Parsing documentation for pastel-0.8.0
Installing ri documentation for pastel-0.8.0
Parsing documentation for tty-prompt-0.23.1
Installing ri documentation for tty-prompt-0.23.1
Parsing documentation for thor-1.1.0
Installing ri documentation for thor-1.1.0
Parsing documentation for paint-2.2.1
Installing ri documentation for paint-2.2.1
Parsing documentation for google-protobuf-3.19.1-x86_64-darwin
unable to convert "\xDB" from ASCII-8BIT to UTF-8 for lib/google/protobuf/descriptor_pb.rb, skipping
Installing ri documentation for google-protobuf-3.19.1-x86_64-darwin
Parsing documentation for googleapis-common-protos-types-1.3.0
Installing ri documentation for googleapis-common-protos-types-1.3.0
Parsing documentation for grpc-1.41.1-universal-darwin
Installing ri documentation for grpc-1.41.1-universal-darwin
Parsing documentation for googleapis-common-protos-1.3.12
Installing ri documentation for googleapis-common-protos-1.3.12
Parsing documentation for grpc-google-iam-v1-1.0.0
Installing ri documentation for grpc-google-iam-v1-1.0.0
Parsing documentation for google-cloud-errors-1.2.0
Installing ri documentation for google-cloud-errors-1.2.0
Parsing documentation for multi_json-1.15.0
Installing ri documentation for multi_json-1.15.0
Parsing documentation for jwt-2.3.0
Installing ri documentation for jwt-2.3.0
Parsing documentation for ruby2_keywords-0.0.5
Installing ri documentation for ruby2_keywords-0.0.5
Parsing documentation for multipart-post-2.1.1
Installing ri documentation for multipart-post-2.1.1
Parsing documentation for faraday-rack-1.0.0
Installing ri documentation for faraday-rack-1.0.0
Parsing documentation for faraday-patron-1.0.0
Installing ri documentation for faraday-patron-1.0.0
Parsing documentation for faraday-net_http_persistent-1.2.0
Installing ri documentation for faraday-net_http_persistent-1.2.0
Parsing documentation for faraday-net_http-1.0.1
Installing ri documentation for faraday-net_http-1.0.1
Parsing documentation for faraday-httpclient-1.0.1
Installing ri documentation for faraday-httpclient-1.0.1
Parsing documentation for faraday-excon-1.1.0
Installing ri documentation for faraday-excon-1.1.0
Parsing documentation for faraday-em_synchrony-1.0.0
Installing ri documentation for faraday-em_synchrony-1.0.0
Parsing documentation for faraday-em_http-1.0.0
Installing ri documentation for faraday-em_http-1.0.0
Parsing documentation for faraday-1.8.0
Installing ri documentation for faraday-1.8.0
Parsing documentation for public_suffix-4.0.6
Installing ri documentation for public_suffix-4.0.6
Parsing documentation for addressable-2.8.0
Installing ri documentation for addressable-2.8.0
Parsing documentation for signet-0.16.0
Installing ri documentation for signet-0.16.0
Parsing documentation for os-1.1.4
Installing ri documentation for os-1.1.4
Parsing documentation for memoist-0.16.2
Installing ri documentation for memoist-0.16.2
Parsing documentation for googleauth-1.1.0
Installing ri documentation for googleauth-1.1.0
Parsing documentation for gapic-common-0.7.0
Installing ri documentation for gapic-common-0.7.0
Parsing documentation for google-cloud-pubsub-v1-0.6.1
Installing ri documentation for google-cloud-pubsub-v1-0.6.1
Parsing documentation for google-cloud-env-1.5.0
Installing ri documentation for google-cloud-env-1.5.0
Parsing documentation for google-cloud-core-1.6.0
Installing ri documentation for google-cloud-core-1.6.0
Parsing documentation for concurrent-ruby-1.1.9
Installing ri documentation for concurrent-ruby-1.1.9
Parsing documentation for google-cloud-pubsub-2.9.0
Installing ri documentation for google-cloud-pubsub-2.9.0
Parsing documentation for foreman-0.87.2
Installing ri documentation for foreman-0.87.2
Parsing documentation for zeitwerk-2.5.1
Installing ri documentation for zeitwerk-2.5.1
Parsing documentation for tzinfo-2.0.4
Installing ri documentation for tzinfo-2.0.4
Parsing documentation for i18n-1.8.11
Installing ri documentation for i18n-1.8.11
Parsing documentation for activesupport-6.1.4.1
Installing ri documentation for activesupport-6.1.4.1
Parsing documentation for souls-1.9.15
Installing ri documentation for souls-1.9.15
Done installing documentation for unicode-display_width, whirly, wisper, tty-screen, tty-cursor, tty-reader, tty-color, pastel, tty-prompt, thor, paint, google-protobuf, googleapis-common-protos-types, grpc, googleapis-common-protos, grpc-google-iam-v1, google-cloud-errors, multi_json, jwt, ruby2_keywords, multipart-post, faraday-rack, faraday-patron, faraday-net_http_persistent, faraday-net_http, faraday-httpclient, faraday-excon, faraday-em_synchrony, faraday-em_http, faraday, public_suffix, addressable, signet, os, memoist, googleauth, gapic-common, google-cloud-pubsub-v1, google-cloud-env, google-cloud-core, concurrent-ruby, google-cloud-pubsub, foreman, zeitwerk, tzinfo, i18n, activesupport, souls after 21 seconds
48 gems installed
```

```
❯ souls -v
<internal:/Users/mbp2021/.rbenv/versions/3.0.3/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- graphql (LoadError)
	from <internal:/Users/mbp2021/.rbenv/versions/3.0.3/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /Users/mbp2021/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/souls-1.9.15/lib/souls/index.rb:3:in `<top (required)>'
	from /Users/mbp2021/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/souls-1.9.15/lib/souls.rb:1:in `require_relative'
	from /Users/mbp2021/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/souls-1.9.15/lib/souls.rb:1:in `<top (required)>'
	from <internal:/Users/mbp2021/.rbenv/versions/3.0.3/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/Users/mbp2021/.rbenv/versions/3.0.3/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /Users/mbp2021/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/souls-1.9.15/exe/souls:2:in `<top (required)>'
	from /Users/mbp2021/.rbenv/versions/3.0.3/bin/souls:25:in `load'
	from /Users/mbp2021/.rbenv/versions/3.0.3/bin/souls:25:in `<main>'
```

### Enviroment

- Ruby 3.0.3

---

Best regards,
s4na
